### PR TITLE
Add support for nested arrays of objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^10.0.1",
     "babel-jest": "^24.8.0",
+    "cross-env": "^5.2.0",
     "eslint": "^5.16.0",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-config-prettier": "^4.3.0",
@@ -64,7 +65,7 @@
     "coverage": "jest --coverage --maxWorkers 2",
     "lint": "eslint --ext .js ./src",
     "flow": "./node_modules/.bin/flow",
-    "test": "npm run coverage && npm run lint && npm run flow",
+    "test": "cross-env NODE_ENV=test npm run coverage && npm run lint && npm run flow",
     "semantic-release": "semantic-release",
     "fixture-demo": "./node_modules/.bin/babel-node ./src/__fixtures__/app.js"
   }

--- a/src/ObjectParser.js
+++ b/src/ObjectParser.js
@@ -46,8 +46,8 @@ export default class ObjectParser {
         const args =
           opts && opts.typeName && opts.fieldName
             ? {
-                typeName: `${opts.typeName}_${upperFirst(opts.fieldName)}`,
-                fieldName: '0',
+                typeName: opts.typeName,
+                fieldName: opts.fieldName,
               }
             : {};
         return [(this.getFieldConfig(val, args): any)];

--- a/src/ObjectParser.js
+++ b/src/ObjectParser.js
@@ -42,7 +42,15 @@ export default class ObjectParser {
       if (Array.isArray(value)) {
         const val = value[0];
         if (Array.isArray(val)) return ['JSON'];
-        return [(this.getFieldConfig(val): any)];
+
+        const args =
+          opts && opts.typeName && opts.fieldName
+            ? {
+                typeName: `${opts.typeName}_${upperFirst(opts.fieldName)}`,
+                fieldName: '0',
+              }
+            : {};
+        return [(this.getFieldConfig(val, args): any)];
       }
 
       if (opts && opts.typeName && opts.fieldName) {

--- a/src/__tests__/ObjectParser-test.js
+++ b/src/__tests__/ObjectParser-test.js
@@ -38,6 +38,16 @@ describe('ObjectParser', () => {
         expect(OP.getFieldConfig([false, true])).toEqual(['Boolean']);
       });
 
+      it('of object', () => {
+        const spy = jest.spyOn(OP, 'createTC');
+        const valueAsArrayOfObjects = [{ a: 123 }, { a: 456 }];
+        OP.getFieldConfig(valueAsArrayOfObjects, {
+          typeName: 'ParentTypeName',
+          fieldName: 'subDocument',
+        });
+        expect(spy).toHaveBeenCalledWith('ParentTypeName_SubDocument_0', valueAsArrayOfObjects[0]);
+      });
+
       it('of any', () => {
         expect(OP.getFieldConfig([null])).toEqual(['JSON']);
       });

--- a/src/__tests__/ObjectParser-test.js
+++ b/src/__tests__/ObjectParser-test.js
@@ -45,7 +45,7 @@ describe('ObjectParser', () => {
           typeName: 'ParentTypeName',
           fieldName: 'subDocument',
         });
-        expect(spy).toHaveBeenCalledWith('ParentTypeName_SubDocument_0', valueAsArrayOfObjects[0]);
+        expect(spy).toHaveBeenCalledWith('ParentTypeName_SubDocument', valueAsArrayOfObjects[0]);
       });
 
       it('of any', () => {

--- a/src/__tests__/composeWithJson-test.js
+++ b/src/__tests__/composeWithJson-test.js
@@ -207,4 +207,52 @@ describe('composeWithJson', () => {
       },
     });
   });
+
+  it('check array of swallow objects', async () => {
+    const restApiResponse = {
+      name: 'Luke Skywalker',
+      limbs: [
+        { kind: 'arm', position: 'left', length: 76 },
+        { kind: 'arm', position: 'left', length: 76 },
+        { kind: 'leg', position: 'left', length: 81 },
+        { kind: 'leg', position: 'right', length: 82 },
+      ],
+    };
+
+    const PersonTC = composeWithJson('PersonCustom', restApiResponse);
+    const schema1 = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'Query',
+        fields: {
+          person: {
+            type: PersonTC.getType(),
+            resolve: () => {
+              return restApiResponse;
+            },
+          },
+        },
+      }),
+    });
+
+    const res = await graphql.graphql(
+      schema1,
+      `{
+        person {
+          name
+          limbs {
+            length
+          }
+        }
+      }`
+    );
+
+    expect(res).toEqual({
+      data: {
+        person: {
+          name: 'Luke Skywalker',
+          limbs: [{ length: 76 }, { length: 76 }, { length: 81 }, { length: 82 }],
+        },
+      },
+    });
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2388,6 +2388,14 @@ create-error-class@^3.0.0:
   dependencies:
     capture-stack-trace "^1.0.0"
 
+cross-env@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.2.0.tgz#6ecd4c015d5773e614039ee529076669b9d126f2"
+  integrity sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==
+  dependencies:
+    cross-spawn "^6.0.5"
+    is-windows "^1.0.0"
+
 cross-spawn@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -4168,7 +4176,7 @@ is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
 
-is-windows@^1.0.2:
+is-windows@^1.0.0, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
 


### PR DESCRIPTION
Fixes #7. Fixes #8.

Before, for a JSON shape of

```js
{
  name: 'Luke Skywalker',
  limbs: [
    { kind: 'arm', position: 'left', length: 76 },
    { kind: 'arm', position: 'left', length: 76 },
    { kind: 'leg', position: 'left', length: 81 },
    { kind: 'leg', position: 'right', length: 82 },
  ],
}
```

`graphql-compose-json` was calculating the type of the `limbs` field as `[JSON]`. Because of this, you weren’t able to query subfields of the `limb` field. [Reproduction](https://runkit.com/iamakulov/5a70ac71ed36050012ef0f3b)

This PR fixes that issue. Now, the `getFieldConfig` method passes `typeName` and `fieldName` down when it encounters an error, and the library goes deeper into the array.