### PR TITLE
Use all fields when calculating types of arrays of objects

### DIFF
--- a/src/ObjectParser.js
+++ b/src/ObjectParser.js
@@ -40,8 +40,12 @@ export default class ObjectParser {
       if (value === null) return 'JSON';
 
       if (Array.isArray(value)) {
-        const val = value[0];
-        if (Array.isArray(val)) return ['JSON'];
+        if (Array.isArray(value[0])) return ['JSON'];
+
+        const val =
+          typeof value[0] === 'object' && value[0] !== null
+            ? Object.assign({}, ...value)
+            : value[0];
 
         const args =
           opts && opts.typeName && opts.fieldName

--- a/src/__tests__/ObjectParser-test.js
+++ b/src/__tests__/ObjectParser-test.js
@@ -45,7 +45,7 @@ describe('ObjectParser', () => {
           typeName: 'ParentTypeName',
           fieldName: 'subDocument',
         });
-        expect(spy).toHaveBeenCalledWith('ParentTypeName_SubDocument', valueAsArrayOfObjects[0]);
+        expect(spy).toHaveBeenCalledWith('ParentTypeName_SubDocument', { a: 456 });
       });
 
       it('of any', () => {

--- a/src/__tests__/composeWithJson-test.js
+++ b/src/__tests__/composeWithJson-test.js
@@ -213,13 +213,24 @@ describe('composeWithJson', () => {
       name: 'Luke Skywalker',
       limbs: [
         { kind: 'arm', position: 'left', length: 76 },
-        { kind: 'arm', position: 'left', length: 76 },
-        { kind: 'leg', position: 'left', length: 81 },
-        { kind: 'leg', position: 'right', length: 82 },
+        { kind: 'arm', position: 'right', length: 76, ring: true },
+        { kind: 'leg', position: 'left', length: 81, sock: 'red' },
+        { kind: 'leg', position: 'right', length: 82, sock: 'red' },
       ],
     };
 
     const PersonTC = composeWithJson('PersonCustom', restApiResponse);
+    expect(
+      PersonTC.getFieldTC('limbs')
+        .getFieldTC('ring')
+        .getTypeName()
+    ).toEqual('Boolean');
+    expect(
+      PersonTC.getFieldTC('limbs')
+        .getFieldTC('sock')
+        .getTypeName()
+    ).toEqual('String');
+
     const schema1 = new GraphQLSchema({
       query: new GraphQLObjectType({
         name: 'Query',
@@ -241,6 +252,7 @@ describe('composeWithJson', () => {
           name
           limbs {
             length
+            ring
           }
         }
       }`
@@ -250,7 +262,12 @@ describe('composeWithJson', () => {
       data: {
         person: {
           name: 'Luke Skywalker',
-          limbs: [{ length: 76 }, { length: 76 }, { length: 81 }, { length: 82 }],
+          limbs: [
+            { length: 76, ring: null },
+            { length: 76, ring: true },
+            { length: 81, ring: null },
+            { length: 82, ring: null },
+          ],
         },
       },
     });


### PR DESCRIPTION
This is a follow-up for #10. Sorry I figured this late.

I’ve been trying `graphql-compose-json` in my project and realized that calculating types based on the first item of an array is not the best choice. If you have an array of objects returned from an API, some of those objects might omit some optional fields – and, as a result, those fields won’t get included into the generated schema.

For example, for the following JSON:

```js
{
  name: 'Luke Skywalker',
  limbs: [
    { kind: 'arm', position: 'left', length: 76 },
    { kind: 'arm', position: 'right', length: 76, ring: true }
  ],
}
```

the type of the `limbs` property will be calculated roughly as follows:

```gql
type Person_Limbs {
  kind: String
  position: String
  length: String
} 
```

 – and won’t include the `ring` field.

This PR improves that by calling `getFieldConfig` over `Object.assign({}, ...array)` instead of `array[0]`. Technically, this is a breaking change, but given that 4.1.0 was released just yesterday, I doubt somebody got relying on the previous behavior.